### PR TITLE
Delete dcd.py

### DIFF
--- a/dcd.py
+++ b/dcd.py
@@ -1,1 +1,0 @@
-kontol lu


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the dcd.py file as it is no longer needed